### PR TITLE
use plugin.stop to return from run

### DIFF
--- a/lib/logstash/inputs/eventlog.rb
+++ b/lib/logstash/inputs/eventlog.rb
@@ -55,7 +55,7 @@ class LogStash::Inputs::EventLog < LogStash::Inputs::Base
       return # fatal scenario => exit
     end
 
-    loop do
+    while !stop?
 
       begin
         # timeout is needed here otherwise NextEvent prevents logstash from exiting

--- a/spec/inputs/eventlog_spec.rb
+++ b/spec/inputs/eventlog_spec.rb
@@ -2,4 +2,7 @@ require "logstash/devutils/rspec/spec_helper"
 require 'logstash/inputs/eventlog'
 
 describe LogStash::Inputs::EventLog do
+  it_behaves_like "an interruptible input plugin" do
+    let(:config) { { "logfile" => "Application" } }
+  end
 end


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3895

resolves #18