### PR TITLE
use win32eventlog to collect eventlog data

### DIFF
--- a/logstash-input-eventlog.gemspec
+++ b/logstash-input-eventlog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-eventlog'
-  s.version         = '2.0.3'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This input will pull events from a Windows Event Log"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -24,10 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'logstash-codec-plain'
 
-  if RUBY_PLATFORM == 'java'
-    s.platform = RUBY_PLATFORM
-    s.add_runtime_dependency "jruby-win32ole"                   #(unknown license)
-  end
+  s.add_runtime_dependency "win32-eventlog", "~> 0.6.5"  # Artistic 2.0
+  s.add_runtime_dependency "stud", "~> 0.0.22"   # Apache 2.0
   s.add_development_dependency 'logstash-devutils'
 end
-

--- a/spec/inputs/eventlog_spec.rb
+++ b/spec/inputs/eventlog_spec.rb
@@ -3,6 +3,6 @@ require 'logstash/inputs/eventlog'
 
 describe LogStash::Inputs::EventLog, :windows => true do
   it_behaves_like "an interruptible input plugin" do
-    let(:config) { { "logfile" => "Application" } }
+    let(:config) { { "logfile" => "Application", "interval" => 10000000 } }
   end
 end


### PR DESCRIPTION
Change the underlying library to capture Event Logs to win32-eventlog

This seems to be a more stable library than win32ole.

BREAKING API CHANGE: this library only allows reading one logfile at a time, so it changes as such:

```diff
-  config :logfile, :validate => :array, :default => [ "Application", "Security", "System" ]
+  config :logfile, :validate => :string, :validate => [ "Application", "Security", "System" ], :default => "Application"
```

This is a simpler version of #13 that doesn't bring the whole library + sincedb to the plugin, and relies as much as possible in win32-eventlog