### PR TITLE
fix spec for not loading windows specific code when excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 3.0.1
+ - fix spec exclusion for non-windows platform
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/logstash-input-eventlog.gemspec
+++ b/logstash-input-eventlog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-eventlog'
-  s.version         = '3.0.0'
+  s.version         = '3.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This input will pull events from a Windows Event Log"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/eventlog_spec.rb
+++ b/spec/inputs/eventlog_spec.rb
@@ -1,7 +1,11 @@
 require "logstash/devutils/rspec/spec_helper"
-require 'logstash/inputs/eventlog'
 
-describe LogStash::Inputs::EventLog, :windows => true do
+describe "LogStash::Inputs::EventLog", :windows => true do
+
+  before(:all) do
+    require 'logstash/inputs/eventlog'
+  end
+
   it_behaves_like "an interruptible input plugin" do
     let(:config) { { "logfile" => "Application", "interval" => 10000000 } }
   end


### PR DESCRIPTION
this spec was crashing on the `require 'logstash/inputs/eventlog'` line because it was evaluated before performing the `:windows => true` exclusion when running the specs on non-windows platform.

the `describe` cannot use the class name constant since it is not defined anymore by moving the `require` further down so it is now a string.

this fixes elastic/logstash#4167