### PR TITLE
Extract the documentaiton from the ruby file

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -7,7 +7,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 :version: %VERSION%
 :release_date: %RELEASE_DATE%
 :changelog_url: %CHANGELOG_URL%
-:include_path: ../../../logstash/docs/include
+:include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
@@ -37,7 +37,7 @@ To collect Events from the System Event Log, use a config like:
 [id="plugins-{type}s-{plugin}-options"]
 ==== Eventlog Input Configuration Options
 
-This plugin supports the following configuration options plus the <<plugins-{type}s-common-options>> described later.
+This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 
 [cols="<,<,<",options="header",]
 |=======================================================================
@@ -46,7 +46,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-logfile>> |<<string,string>>, one of `["Application", "Security", "System"]`|No
 |=======================================================================
 
-Also see <<plugins-{type}s-common-options>> for a list of options supported by all
+Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
 input plugins.
 
 &nbsp;
@@ -70,5 +70,5 @@ System and Security may require that privileges are given to the user running lo
 see more at: https://social.technet.microsoft.com/forums/windowsserver/en-US/d2f813db-6142-4b5b-8d86-253ebb740473/easy-way-to-read-security-log
 
 
-
+[id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,74 @@
+:plugin: eventlog
+:type: input
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: %VERSION%
+:release_date: %RELEASE_DATE%
+:changelog_url: %CHANGELOG_URL%
+:include_path: ../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}-{plugin}"]
+
+=== Eventlog
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This input will pull events from a http://msdn.microsoft.com/en-us/library/windows/desktop/bb309026%28v=vs.85%29.aspx[Windows Event Log].
+Note that Windows Event Logs are stored on disk in a binary format and are only accessible from the Win32 API.
+This means Losgtash needs to be running as an agent on Windows servers where you wish to collect logs 
+from, and will not be accesible across the network.
+
+To collect Events from the System Event Log, use a config like:
+[source,ruby]
+    input {
+      eventlog {
+        type  => 'Win32-EventLog'
+        logfile  => 'System'
+      }
+    }
+
+[id="plugins-{type}s-{plugin}-options"]
+==== Eventlog Input Configuration Options
+
+This plugin supports the following configuration options plus the <<plugins-{type}s-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-logfile>> |<<string,string>>, one of `["Application", "Security", "System"]`|No
+|=======================================================================
+
+Also see <<plugins-{type}s-common-options>> for a list of options supported by all
+input plugins.
+
+&nbsp;
+
+[id="plugins-{type}s-{plugin}-interval"]
+===== `interval` 
+
+  * Value type is <<number,number>>
+  * Default value is `1000`
+
+How frequently should tail check for new event logs in ms (default: 1 second)
+
+[id="plugins-{type}s-{plugin}-logfile"]
+===== `logfile` 
+
+  * Value can be any of: `Application`, `Security`, `System`
+  * Default value is `"Application"`
+
+Event Log Name
+System and Security may require that privileges are given to the user running logstash.
+see more at: https://social.technet.microsoft.com/forums/windowsserver/en-US/d2f813db-6142-4b5b-8d86-253ebb740473/easy-way-to-read-security-log
+
+
+
+include::{include_path}/{type}.asciidoc[]

--- a/logstash-input-eventlog.gemspec
+++ b/logstash-input-eventlog.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT', 'docs/**/*']
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
This is a manual extract from the ruby doc, this plugins was skipped in the
previous automatted extraction because loading the ruby file require the presence of windows
dll. (Like libadvapi32.dylib)

Fixes: #38
